### PR TITLE
feat: Add Custom OIDC support for oauth configuration

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -456,7 +456,12 @@ func (h *AuthHandler) handleGitHubOAuth(c *gin.Context, code string) {
 		cfg.ClientID, redirectURI, cfg.TokenURL)
 	fmt.Printf("🔍 请求体: %s\n", form.Encode())
 
-	tokenReq, _ := http.NewRequest("POST", cfg.TokenURL, strings.NewReader(form.Encode()))
+	tokenReq, err := http.NewRequest("POST", cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		fmt.Printf("❌ GitHub Token 请求创建失败: %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建 Token 请求失败"})
+		return
+	}
 	tokenReq.Header.Set("Accept", "application/json")
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -505,7 +510,12 @@ func (h *AuthHandler) handleGitHubOAuth(c *gin.Context, code string) {
 	}
 
 	// 获取用户信息
-	userReq, _ := http.NewRequest("GET", cfg.UserInfoURL, nil)
+	userReq, err := http.NewRequest("GET", cfg.UserInfoURL, nil)
+	if err != nil {
+		fmt.Printf("❌ GitHub 用户信息请求创建失败: %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建用户信息请求失败"})
+		return
+	}
 	userReq.Header.Set("Authorization", "token "+tokenRes.AccessToken)
 	userReq.Header.Set("Accept", "application/json")
 
@@ -632,7 +642,12 @@ func (h *AuthHandler) handleCloudflareOAuth(c *gin.Context, code string) {
 	}
 	form.Set("redirect_uri", redirectURI)
 
-	tokenReq, _ := http.NewRequest("POST", cfg.TokenURL, strings.NewReader(form.Encode()))
+	tokenReq, err := http.NewRequest("POST", cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		fmt.Printf("❌ Cloudflare Token 请求创建失败: %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建 Token 请求失败"})
+		return
+	}
 	tokenReq.Header.Set("Accept", "application/json")
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -686,7 +701,12 @@ func (h *AuthHandler) handleCloudflareOAuth(c *gin.Context, code string) {
 		return
 	}
 
-	userReq, _ := http.NewRequest("GET", cfg.UserInfoURL, nil)
+	userReq, err := http.NewRequest("GET", cfg.UserInfoURL, nil)
+	if err != nil {
+		fmt.Printf("❌ Cloudflare 用户信息请求创建失败: %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建用户信息请求失败"})
+		return
+	}
 	userReq.Header.Set("Authorization", "Bearer "+tokenRes.AccessToken)
 	userReq.Header.Set("Accept", "application/json")
 
@@ -865,10 +885,9 @@ func (h *AuthHandler) HandleOAuth2Config(c *gin.Context) {
 				return
 			}
 
-			// 3. Discovery（仅允许 HTTPS，支持内网 IP）
+			// 3. Discovery（强制使用 HTTPS，支持内网 IP）
 			validator := &auth.URLValidator{
-				AllowHTTP:      false, // 仅允许 HTTPS
-				AllowPrivateIP: true,  // 支持内网 IP（需 HTTPS）
+				AllowPrivateIP: true, // 支持内网 IP（使用 HTTPS）
 			}
 
 			discoveredConfig, err := auth.SecureDiscoverOIDC(issuerURL, validator)
@@ -1050,7 +1069,12 @@ func (h *AuthHandler) handleCustomOIDC(c *gin.Context, code string) {
 
 	fmt.Printf("🔍 Custom OIDC Token 请求: token_url=%s, redirect_uri=%s\n", cfg.TokenURL, redirectURI)
 
-	tokenReq, _ := http.NewRequest("POST", cfg.TokenURL, strings.NewReader(form.Encode()))
+	tokenReq, err := http.NewRequest("POST", cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		fmt.Printf("❌ Custom OIDC Token 请求创建失败: %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建 Token 请求失败"})
+		return
+	}
 	tokenReq.Header.Set("Accept", "application/json")
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -1105,7 +1129,12 @@ func (h *AuthHandler) handleCustomOIDC(c *gin.Context, code string) {
 		return
 	}
 
-	userReq, _ := http.NewRequest("GET", cfg.UserInfoURL, nil)
+	userReq, err := http.NewRequest("GET", cfg.UserInfoURL, nil)
+	if err != nil {
+		fmt.Printf("❌ Custom OIDC 用户信息请求创建失败: %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建用户信息请求失败"})
+		return
+	}
 	userReq.Header.Set("Authorization", "Bearer "+tokenRes.AccessToken)
 	userReq.Header.Set("Accept", "application/json")
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1175,22 +1175,16 @@ func (h *AuthHandler) HandleOAuth2Provider(c *gin.Context) {
 }
 
 // HandleOIDCDiscover 处理 OIDC Discovery 请求
-// GET /api/oauth2/discover?issuer=https://auth.example.com
+// GET /api/oauth2/discover?url=https://auth.example.com/.well-known/openid-configuration
 func (h *AuthHandler) HandleOIDCDiscover(c *gin.Context) {
-	issuerURL := c.Query("issuer")
-	if issuerURL == "" {
+	discoveryURL := c.Query("url")
+	if discoveryURL == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
-			"error":   "缺少 issuer 参数",
+			"error":   "缺少 url 参数",
 		})
 		return
 	}
-
-	// 确保 issuerURL 不以 / 结尾
-	issuerURL = strings.TrimSuffix(issuerURL, "/")
-
-	// 构建 well-known 地址
-	discoveryURL := issuerURL + "/.well-known/openid-configuration"
 
 	// 使用支持代理的 HTTP 客户端
 	proxyClient := h.createProxyClient()
@@ -1199,7 +1193,7 @@ func (h *AuthHandler) HandleOIDCDiscover(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
-			"error":   "无效的 Issuer URL",
+			"error":   "无效的 Discovery URL",
 		})
 		return
 	}

--- a/internal/api/tunnel.go
+++ b/internal/api/tunnel.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"NodePassDash/internal/auth"
 	log "NodePassDash/internal/log"
 	"NodePassDash/internal/metrics"
 	"NodePassDash/internal/models"
@@ -2390,11 +2391,11 @@ func (h *TunnelHandler) HandleGetTunnelTrafficTrend(c *gin.Context) {
 				}()
 
 				sortedPoints = append(sortedPoints, TrafficPoint{
-					EventTime: record["eventTime"].(string),
-					TcpRx:     record["tcpRx"].(int64),
-					TcpTx:     record["tcpTx"].(int64),
-					UdpRx:     record["udpRx"].(int64),
-					UdpTx:     record["udpTx"].(int64),
+					EventTime: auth.SafeStringAssert(record["eventTime"], ""),
+					TcpRx:     auth.SafeInt64Assert(record["tcpRx"], 0),
+					TcpTx:     auth.SafeInt64Assert(record["tcpTx"], 0),
+					UdpRx:     auth.SafeInt64Assert(record["udpRx"], 0),
+					UdpTx:     auth.SafeInt64Assert(record["udpTx"], 0),
 					Pool:      poolVal,
 					Ping:      pingVal,
 				})

--- a/internal/api/tunnel.go
+++ b/internal/api/tunnel.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"NodePassDash/internal/auth"
 	log "NodePassDash/internal/log"
 	"NodePassDash/internal/metrics"
 	"NodePassDash/internal/models"
@@ -2391,11 +2390,11 @@ func (h *TunnelHandler) HandleGetTunnelTrafficTrend(c *gin.Context) {
 				}()
 
 				sortedPoints = append(sortedPoints, TrafficPoint{
-					EventTime: auth.SafeStringAssert(record["eventTime"], ""),
-					TcpRx:     auth.SafeInt64Assert(record["tcpRx"], 0),
-					TcpTx:     auth.SafeInt64Assert(record["tcpTx"], 0),
-					UdpRx:     auth.SafeInt64Assert(record["udpRx"], 0),
-					UdpTx:     auth.SafeInt64Assert(record["udpTx"], 0),
+					EventTime: record["eventTime"].(string),
+					TcpRx:     record["tcpRx"].(int64),
+					TcpTx:     record["tcpTx"].(int64),
+					UdpRx:     record["udpRx"].(int64),
+					UdpTx:     record["udpTx"].(int64),
 					Pool:      poolVal,
 					Ping:      pingVal,
 				})

--- a/internal/auth/helpers.go
+++ b/internal/auth/helpers.go
@@ -37,23 +37,3 @@ func SafeStringAssert(v interface{}, fallback string) string {
 	}
 	return fallback
 }
-
-// SafeInt64Assert 安全地断言为 int64,失败返回默认值
-func SafeInt64Assert(v interface{}, fallback int64) int64 {
-	if v == nil {
-		return fallback
-	}
-	// 尝试 int64
-	if i, ok := v.(int64); ok {
-		return i
-	}
-	// 尝试 float64 (JSON 默认数字类型)
-	if f, ok := v.(float64); ok {
-		return int64(f)
-	}
-	// 尝试 int
-	if i, ok := v.(int); ok {
-		return int64(i)
-	}
-	return fallback
-}

--- a/internal/auth/helpers.go
+++ b/internal/auth/helpers.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// UnmarshalConfig 安全地解析配置 JSON 字符串
+func UnmarshalConfig(data string, v interface{}) error {
+	if data == "" {
+		return fmt.Errorf("配置为空")
+	}
+	if err := json.Unmarshal([]byte(data), v); err != nil {
+		return fmt.Errorf("解析配置失败: %w", err)
+	}
+	return nil
+}
+
+// UnmarshalBytes 安全地解析字节数据为 JSON
+func UnmarshalBytes(data []byte, v interface{}) error {
+	if len(data) == 0 {
+		return fmt.Errorf("数据为空")
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("解析数据失败: %w", err)
+	}
+	return nil
+}
+
+// SafeStringAssert 安全地断言为字符串,失败返回默认值
+func SafeStringAssert(v interface{}, fallback string) string {
+	if v == nil {
+		return fallback
+	}
+	if s, ok := v.(string); ok && s != "" {
+		return s
+	}
+	return fallback
+}
+
+// SafeInt64Assert 安全地断言为 int64,失败返回默认值
+func SafeInt64Assert(v interface{}, fallback int64) int64 {
+	if v == nil {
+		return fallback
+	}
+	// 尝试 int64
+	if i, ok := v.(int64); ok {
+		return i
+	}
+	// 尝试 float64 (JSON 默认数字类型)
+	if f, ok := v.(float64); ok {
+		return int64(f)
+	}
+	// 尝试 int
+	if i, ok := v.(int); ok {
+		return int64(i)
+	}
+	return fallback
+}

--- a/internal/auth/security.go
+++ b/internal/auth/security.go
@@ -1,0 +1,157 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// URLValidator URL 验证器
+type URLValidator struct {
+	AllowHTTP      bool // 是否允许 HTTP (默认允许,支持内网部署)
+	AllowPrivateIP bool // 是否允许私有 IP (默认允许,支持内网部署)
+}
+
+// ValidateURL 验证 URL 的安全性
+func (v *URLValidator) ValidateURL(rawURL string) error {
+	// 解析 URL
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("无效的 URL 格式: %w", err)
+	}
+
+	// 检查 scheme
+	scheme := strings.ToLower(parsedURL.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("不支持的协议 %s, 仅允许 HTTP/HTTPS", scheme)
+	}
+
+	// 如果不允许 HTTP,则强制 HTTPS
+	if !v.AllowHTTP && scheme == "http" {
+		return fmt.Errorf("不允许使用 HTTP 协议,请使用 HTTPS")
+	}
+
+	// 检查 host 是否为空
+	if parsedURL.Host == "" {
+		return fmt.Errorf("URL 缺少 host")
+	}
+
+	// 如果不允许私有 IP,则检查 IP 地址
+	if !v.AllowPrivateIP {
+		// 提取 hostname (去除端口)
+		hostname := parsedURL.Hostname()
+
+		// 解析 IP
+		ip := net.ParseIP(hostname)
+		if ip == nil {
+			// 如果不是 IP,尝试解析域名
+			ips, err := net.LookupIP(hostname)
+			if err == nil && len(ips) > 0 {
+				ip = ips[0]
+			}
+		}
+
+		// 检查是否为私有 IP
+		if ip != nil && v.isPrivateIP(ip) {
+			return fmt.Errorf("不允许访问私有 IP 地址: %s", ip.String())
+		}
+	}
+
+	return nil
+}
+
+// isPrivateIP 检查 IP 是否为私有地址
+func (v *URLValidator) isPrivateIP(ip net.IP) bool {
+	// 检查 loopback
+	if ip.IsLoopback() {
+		return true
+	}
+
+	// 检查私有 IP 范围
+	privateRanges := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"fc00::/7", // IPv6 unique local addresses
+	}
+
+	for _, cidr := range privateRanges {
+		_, ipnet, _ := net.ParseCIDR(cidr)
+		if ipnet.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// OIDCConfig OIDC 配置
+type OIDCConfig struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	UserinfoEndpoint      string `json:"userinfo_endpoint"`
+}
+
+// SecureDiscoverOIDC 安全地执行 OIDC Discovery
+func SecureDiscoverOIDC(issuer string, validator *URLValidator) (*OIDCConfig, error) {
+	// 构造 Discovery URL
+	issuer = strings.TrimSuffix(issuer, "/")
+	discoveryURL := issuer + "/.well-known/openid-configuration"
+
+	// 验证 Discovery URL
+	if err := validator.ValidateURL(discoveryURL); err != nil {
+		return nil, fmt.Errorf("Discovery URL 验证失败: %w", err)
+	}
+
+	// 发起 HTTP 请求
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	req, err := http.NewRequest("GET", discoveryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("创建请求失败: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Discovery 请求失败,状态码: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("读取响应失败: %w", err)
+	}
+
+	// 解析配置
+	var config OIDCConfig
+	if err := json.Unmarshal(body, &config); err != nil {
+		return nil, fmt.Errorf("解析配置失败: %w", err)
+	}
+
+	// 验证 issuer 一致性
+	responseIssuer := strings.TrimSuffix(config.Issuer, "/")
+	expectedIssuer := strings.TrimSuffix(issuer, "/")
+	if responseIssuer != expectedIssuer {
+		return nil, fmt.Errorf("issuer 不匹配: 请求 %s, 响应 %s", expectedIssuer, responseIssuer)
+	}
+
+	// 验证必要端点
+	if config.AuthorizationEndpoint == "" || config.TokenEndpoint == "" {
+		return nil, fmt.Errorf("配置不完整,缺少必要端点")
+	}
+
+	return &config, nil
+}

--- a/web/src/components/settings/security-settings.tsx
+++ b/web/src/components/settings/security-settings.tsx
@@ -516,9 +516,14 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
       onCustomOpenChange();
     } catch (error) {
       console.error("保存 Custom OIDC 配置失败:", error);
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "无法连接到 OIDC 服务器，请检查 Issuer URL";
+
       addToast({
         title: "保存失败",
-        description: error.message || "无法连接到 OIDC 服务器，请检查 Issuer URL",
+        description: errorMessage,
         color: "danger",
       });
     } finally {

--- a/web/src/components/settings/security-settings.tsx
+++ b/web/src/components/settings/security-settings.tsx
@@ -1,4 +1,6 @@
 import {
+  Accordion,
+  AccordionItem,
   Button,
   Card,
   CardBody,
@@ -442,8 +444,8 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
   const handleDiscoverOIDC = async () => {
     if (!customConfig.issuerUrl) {
       addToast({
-        title: "请输入 Issuer URL",
-        description: "Issuer URL 不能为空",
+        title: "请输入 Discovery URL",
+        description: "Discovery URL 不能为空",
         color: "warning",
       });
       return;
@@ -452,7 +454,7 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
     setIsDiscovering(true);
     try {
       const res = await fetch(
-        buildApiUrl(`/api/oauth2/discover?issuer=${encodeURIComponent(customConfig.issuerUrl)}`)
+        buildApiUrl(`/api/oauth2/discover?url=${encodeURIComponent(customConfig.issuerUrl)}`)
       );
       const data = await res.json();
 
@@ -1172,13 +1174,13 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
               </ModalHeader>
               <ModalBody>
                 <div className="space-y-4">
-                  {/* Issuer URL + 发现按钮 */}
-                  <div className="flex gap-2 items-end">
+                  {/* Discovery URL + 发现按钮 */}
+                  <div className="flex gap-2">
                     <Input
                       className="flex-1"
-                      label="Issuer URL"
-                      placeholder="https://auth.example.com/realms/myrealm"
-                      description="OIDC 服务的 Issuer 地址"
+                      label="Discovery URL"
+                      placeholder="https://auth.example.com/.well-known/openid-configuration"
+                      description="OIDC 发现端点的完整地址"
                       value={customConfig.issuerUrl}
                       onChange={(e) =>
                         setCustomConfig((prev) => ({
@@ -1188,6 +1190,7 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
                       }
                     />
                     <Button
+                      className="mt-6 h-14 min-w-[72px]"
                       color="primary"
                       variant="flat"
                       isLoading={isDiscovering}
@@ -1277,6 +1280,65 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
                       }))
                     }
                   />
+
+                  {/* 高级配置 */}
+                  <Accordion variant="bordered" className="px-0">
+                    <AccordionItem
+                      key="advanced"
+                      aria-label="高级配置"
+                      title={
+                        <span className="text-sm font-medium">高级配置</span>
+                      }
+                      subtitle={
+                        <span className="text-xs text-default-400">
+                          Scopes、用户字段映射等
+                        </span>
+                      }
+                    >
+                      <div className="space-y-4 pb-2">
+                        <Input
+                          label="Scopes"
+                          placeholder="openid profile email"
+                          description="OAuth2 作用域，多个用空格分隔"
+                          value={(customConfig.scopes || []).join(" ")}
+                          onChange={(e) => {
+                            const scopesStr = e.target.value;
+                            const scopesArr = scopesStr
+                              .split(/\s+/)
+                              .filter((s) => s.length > 0);
+                            setCustomConfig((prev) => ({
+                              ...prev,
+                              scopes: scopesArr.length > 0 ? scopesArr : ["openid", "profile", "email"],
+                            }));
+                          }}
+                        />
+                        <Input
+                          label="User ID Path"
+                          placeholder="sub"
+                          description="从用户信息中提取用户 ID 的字段路径，支持点号路径如 user.id"
+                          value={customConfig.userIdPath}
+                          onChange={(e) =>
+                            setCustomConfig((prev) => ({
+                              ...prev,
+                              userIdPath: e.target.value || "sub",
+                            }))
+                          }
+                        />
+                        <Input
+                          label="Username Path"
+                          placeholder="preferred_username"
+                          description="从用户信息中提取用户名的字段路径，支持点号路径如 user.name"
+                          value={customConfig.usernamePath}
+                          onChange={(e) =>
+                            setCustomConfig((prev) => ({
+                              ...prev,
+                              usernamePath: e.target.value || "preferred_username",
+                            }))
+                          }
+                        />
+                      </div>
+                    </AccordionItem>
+                  </Accordion>
                 </div>
               </ModalBody>
               <ModalFooter>

--- a/web/src/components/settings/security-settings.tsx
+++ b/web/src/components/settings/security-settings.tsx
@@ -1227,6 +1227,15 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
                     }
                   />
 
+                  {/* Callback URL (只读) */}
+                  <Input
+                    label="Callback URL"
+                    description="请将此地址填写到 OIDC 客户端的回调 URL / Redirect URI 配置中"
+                    value={`${window.location.origin}/api/oauth2/callback`}
+                    isReadOnly
+                    variant="flat"
+                  />
+
                   <Divider />
 
                   {/* OIDC 端点 */}

--- a/web/src/components/settings/security-settings.tsx
+++ b/web/src/components/settings/security-settings.tsx
@@ -1,6 +1,4 @@
 import {
-  Accordion,
-  AccordionItem,
   Button,
   Card,
   CardBody,
@@ -1174,31 +1172,19 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
               </ModalHeader>
               <ModalBody>
                 <div className="space-y-4">
-                  {/* Discovery URL + 发现按钮 */}
-                  <div className="flex gap-2">
-                    <Input
-                      className="flex-1"
-                      label="Discovery URL"
-                      placeholder="https://auth.example.com/.well-known/openid-configuration"
-                      description="OIDC 发现端点的完整地址"
-                      value={customConfig.issuerUrl}
-                      onChange={(e) =>
-                        setCustomConfig((prev) => ({
-                          ...prev,
-                          issuerUrl: e.target.value,
-                        }))
-                      }
-                    />
-                    <Button
-                      className="mt-6 h-14 min-w-[72px]"
-                      color="primary"
-                      variant="flat"
-                      isLoading={isDiscovering}
-                      onPress={handleDiscoverOIDC}
-                    >
-                      发现
-                    </Button>
-                  </div>
+                  {/* Discovery URL */}
+                  <Input
+                    label="Discovery URL"
+                    placeholder="https://auth.example.com/.well-known/openid-configuration"
+                    description="OIDC 发现端点的完整地址，点击「发现」自动填充下方端点"
+                    value={customConfig.issuerUrl}
+                    onChange={(e) =>
+                      setCustomConfig((prev) => ({
+                        ...prev,
+                        issuerUrl: e.target.value,
+                      }))
+                    }
+                  />
 
                   <Divider />
 
@@ -1243,10 +1229,7 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
 
                   <Divider />
 
-                  {/* OIDC 端点（通常由发现自动填充） */}
-                  <p className="text-sm text-default-500">
-                    以下端点通常由「发现」自动填充，也可手动修改
-                  </p>
+                  {/* OIDC 端点 */}
                   <Input
                     label="Auth URL"
                     placeholder="授权端点 (authorization_endpoint)"
@@ -1281,69 +1264,65 @@ const SecuritySettings = forwardRef<SecuritySettingsRef, {}>((props, ref) => {
                     }
                   />
 
-                  {/* 高级配置 */}
-                  <Accordion variant="bordered" className="px-0">
-                    <AccordionItem
-                      key="advanced"
-                      aria-label="高级配置"
-                      title={
-                        <span className="text-sm font-medium">高级配置</span>
-                      }
-                      subtitle={
-                        <span className="text-xs text-default-400">
-                          Scopes、用户字段映射等
-                        </span>
-                      }
-                    >
-                      <div className="space-y-4 pb-2">
-                        <Input
-                          label="Scopes"
-                          placeholder="openid profile email"
-                          description="OAuth2 作用域，多个用空格分隔"
-                          value={(customConfig.scopes || []).join(" ")}
-                          onChange={(e) => {
-                            const scopesStr = e.target.value;
-                            const scopesArr = scopesStr
-                              .split(/\s+/)
-                              .filter((s) => s.length > 0);
-                            setCustomConfig((prev) => ({
-                              ...prev,
-                              scopes: scopesArr.length > 0 ? scopesArr : ["openid", "profile", "email"],
-                            }));
-                          }}
-                        />
-                        <Input
-                          label="User ID Path"
-                          placeholder="sub"
-                          description="从用户信息中提取用户 ID 的字段路径，支持点号路径如 user.id"
-                          value={customConfig.userIdPath}
-                          onChange={(e) =>
-                            setCustomConfig((prev) => ({
-                              ...prev,
-                              userIdPath: e.target.value || "sub",
-                            }))
-                          }
-                        />
-                        <Input
-                          label="Username Path"
-                          placeholder="preferred_username"
-                          description="从用户信息中提取用户名的字段路径，支持点号路径如 user.name"
-                          value={customConfig.usernamePath}
-                          onChange={(e) =>
-                            setCustomConfig((prev) => ({
-                              ...prev,
-                              usernamePath: e.target.value || "preferred_username",
-                            }))
-                          }
-                        />
-                      </div>
-                    </AccordionItem>
-                  </Accordion>
+                  <Divider />
+
+                  {/* Scopes 和字段映射 */}
+                  <Input
+                    label="Scopes"
+                    placeholder="openid profile email"
+                    description="OAuth2 作用域，多个用空格分隔"
+                    value={(customConfig.scopes || []).join(" ")}
+                    onChange={(e) => {
+                      const scopesStr = e.target.value;
+                      const scopesArr = scopesStr
+                        .split(/\s+/)
+                        .filter((s) => s.length > 0);
+                      setCustomConfig((prev) => ({
+                        ...prev,
+                        scopes:
+                          scopesArr.length > 0
+                            ? scopesArr
+                            : ["openid", "profile", "email"],
+                      }));
+                    }}
+                  />
+                  <Input
+                    label="User ID Path"
+                    placeholder="sub"
+                    description="从用户信息中提取用户 ID 的字段路径，支持点号路径如 user.id"
+                    value={customConfig.userIdPath}
+                    onChange={(e) =>
+                      setCustomConfig((prev) => ({
+                        ...prev,
+                        userIdPath: e.target.value || "sub",
+                      }))
+                    }
+                  />
+                  <Input
+                    label="Username Path"
+                    placeholder="preferred_username"
+                    description="从用户信息中提取用户名的字段路径，支持点号路径如 user.name"
+                    value={customConfig.usernamePath}
+                    onChange={(e) =>
+                      setCustomConfig((prev) => ({
+                        ...prev,
+                        usernamePath: e.target.value || "preferred_username",
+                      }))
+                    }
+                  />
                 </div>
               </ModalBody>
               <ModalFooter>
                 <Button color="default" variant="light" onPress={onClose}>
                   取消
+                </Button>
+                <Button
+                  color="primary"
+                  variant="flat"
+                  isLoading={isDiscovering}
+                  onPress={handleDiscoverOIDC}
+                >
+                  发现
                 </Button>
                 <Button
                   color="primary"

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -38,7 +38,8 @@ export default function LoginPage() {
 
   // OAuth2 配置状态
   const [oauthProviders, setOauthProviders] = useState<{
-    provider?: "github" | "cloudflare";
+    provider?: "github" | "cloudflare" | "custom";
+    displayName?: string;
     config?: any;
   }>({});
   // 是否禁用用户名密码登录
@@ -58,7 +59,7 @@ export default function LoginPage() {
      */
     const fetchCurrentProvider = async () => {
       try {
-        const res = await fetch("/api/auth/oauth2"); // 仅返回 provider 和 disableLogin
+        const res = await fetch("/api/auth/oauth2"); // 仅返回 provider、disableLogin 和 displayName（custom 时）
         const data = await res.json();
 
         if (data.success) {
@@ -66,9 +67,12 @@ export default function LoginPage() {
           const loginDisabled = data.disableLogin === true;
 
           if (data.provider) {
-            const cur = data.provider as "github" | "cloudflare";
+            const cur = data.provider as "github" | "cloudflare" | "custom";
 
-            setOauthProviders({ provider: cur });
+            setOauthProviders({
+              provider: cur,
+              displayName: data.displayName || undefined,
+            });
           }
 
           // 设置是否禁用用户名密码登录
@@ -324,6 +328,20 @@ export default function LoginPage() {
                         }}
                       >
                         使用 Cloudflare 登录
+                      </Button>
+                    )}
+                    {oauthProviders.provider === "custom" && (
+                      <Button
+                        color="default"
+                        startContent={
+                          <Icon icon="solar:key-bold" width={20} />
+                        }
+                        variant="bordered"
+                        onPress={() => {
+                          window.location.href = "/api/oauth2/login";
+                        }}
+                      >
+                        使用 {oauthProviders.displayName || "OIDC"} 登录
                       </Button>
                     )}
                   </div>


### PR DESCRIPTION
1. Add custom OIDC support for backend server.
2. Add custom OIDC configuration form.

background:
Pocket ID is a self hosted OIDC provider which can easily provide the passkey login ability.

login page:
<img width="960" height="1099" alt="image" src="https://github.com/user-attachments/assets/19beb05a-b0e6-4f51-aa2a-0fc823f34ccf" />

Click Login with Pocket ID
<img width="1871" height="1448" alt="image" src="https://github.com/user-attachments/assets/e03e8953-3a59-4528-b73c-88fb30022dd8" />

Oauth configuration page:
<img width="1809" height="276" alt="image" src="https://github.com/user-attachments/assets/b1db0683-8238-491c-a605-bbb3291f667a" />

form:
<img width="865" height="528" alt="image" src="https://github.com/user-attachments/assets/21a50a7b-991e-46e8-8ad8-40d23a865234" />
<img width="1038" height="1332" alt="image" src="https://github.com/user-attachments/assets/2ac89a43-59f7-42f0-b891-29dab8c444fc" />



Tested in my local env, everything works well.




demo: 